### PR TITLE
Fix speedtest-cli installation

### DIFF
--- a/speedtest/Dockerfile
+++ b/speedtest/Dockerfile
@@ -7,7 +7,7 @@ RUN npm install
 
 RUN apt-get update -y
 RUN apt-get install -y gnupg1 apt-transport-https dirmngr iputils-ping
-RUN curl -s https://install.speedtest.net/app/cli/install.deb.sh | bash
+RUN curl -s https://packagecloud.io/install/repositories/ookla/speedtest-cli/script.deb.sh | bash
 RUN apt-get update
 RUN apt-get install speedtest
 


### PR DESCRIPTION
The script have problems and the correct one in the https://www.speedtest.net/es/apps/cli is this
curl -s https://packagecloud.io/install/repositories/ookla/speedtest-cli/script.deb.sh | sudo bash